### PR TITLE
use `XDG_CACHE_HOME` if `/tmp` is nosuid

### DIFF
--- a/AppDir/AppRun
+++ b/AppDir/AppRun
@@ -61,7 +61,7 @@ fi
 if [ -n "$1" ] && [ -f "$WORKAROUND_PATH"/bin/"$1" ]; then
 	BIN="$1"
 	shift
-	"$WORKAROUND_PATH"/bin/"$BIN" "$@"
+	exec "$WORKAROUND_PATH"/bin/"$BIN" "$@"
 else
-	"$WORKAROUND_PATH"/bin/gpu-screen-recorder-gtk "$@"
+	exec "$WORKAROUND_PATH"/bin/gpu-screen-recorder-gtk "$@"
 fi

--- a/AppDir/AppRun
+++ b/AppDir/AppRun
@@ -15,6 +15,14 @@ for dep in $dependencies; do
 	fi
 done
 
+_cleanup() {
+	if [ -d "$WORKAROUND_PATH" ]; then
+		rm -rf "$WORKAROUND_PATH"
+	fi
+}
+
+trap _cleanup INT TERM EXIT
+
 # gsr binaries were patched to look for data files in '/tmp/._gsr'
 ln -sfn "$APPDIR"/share /tmp/._gsr
 
@@ -65,5 +73,3 @@ if [ -n "$1" ] && [ -f "$WORKAROUND_PATH"/bin/"$1" ]; then
 else
 	"$WORKAROUND_PATH"/bin/gpu-screen-recorder-gtk "$@"
 fi
-
-rm -rf "$WORKAROUND_PATH"

--- a/AppDir/AppRun
+++ b/AppDir/AppRun
@@ -6,7 +6,7 @@ BIN="${ARGV0:-$0}"
 BIN="${BIN#./}"
 unset ARGV0
 
-dependencies="getcap pkexec ln mkdir"
+dependencies="getcap pkexec ln mkdir grep rm"
 for dep in $dependencies; do
 	if ! command -v $dep 1>/dev/null; then
 		>&2 echo "ERROR: Missing dependency '$dep'"
@@ -19,8 +19,12 @@ done
 ln -sfn "$APPDIR"/share /tmp/._gsr
 
 # gsr needs capabilities, so this ugly hack is needed for that
-# TODO detect when /tmp is mounted with nonsuid and look for another place
-WORKAROUND_PATH="/tmp/.gsr-appimage-hack"
+if grep '/tmp .*nosuid' /proc/mounts; then
+	WORKAROUND_PATH="${XDG_CACHE_HOME:-$HOME/.cache}"/gsr-appimage-hack
+else
+	WORKAROUND_PATH="/tmp/.gsr-appimage-hack"
+fi
+
 mkdir -p "$WORKAROUND_PATH"/bin
 
 # hack to get capabities working
@@ -57,7 +61,9 @@ fi
 if [ -n "$1" ] && [ -f "$WORKAROUND_PATH"/bin/"$1" ]; then
 	BIN="$1"
 	shift
-	exec "$WORKAROUND_PATH"/bin/"$BIN" "$@"
+	"$WORKAROUND_PATH"/bin/"$BIN" "$@"
 else
-	exec "$WORKAROUND_PATH"/bin/gpu-screen-recorder-gtk "$@"
+	"$WORKAROUND_PATH"/bin/gpu-screen-recorder-gtk "$@"
 fi
+
+rm -rf "$WORKAROUND_PATH"

--- a/AppDir/AppRun
+++ b/AppDir/AppRun
@@ -6,7 +6,7 @@ BIN="${ARGV0:-$0}"
 BIN="${BIN#./}"
 unset ARGV0
 
-dependencies="getcap pkexec ln mkdir grep rm"
+dependencies="getcap pkexec ln mkdir grep"
 for dep in $dependencies; do
 	if ! command -v $dep 1>/dev/null; then
 		>&2 echo "ERROR: Missing dependency '$dep'"
@@ -14,14 +14,6 @@ for dep in $dependencies; do
 		exit 1
 	fi
 done
-
-_cleanup() {
-	if [ -d "$WORKAROUND_PATH" ]; then
-		rm -rf "$WORKAROUND_PATH"
-	fi
-}
-
-trap _cleanup INT TERM EXIT
 
 # gsr binaries were patched to look for data files in '/tmp/._gsr'
 ln -sfn "$APPDIR"/share /tmp/._gsr

--- a/AppDir/AppRun
+++ b/AppDir/AppRun
@@ -19,7 +19,7 @@ done
 ln -sfn "$APPDIR"/share /tmp/._gsr
 
 # gsr needs capabilities, so this ugly hack is needed for that
-if grep '/tmp .*nosuid' /proc/mounts; then
+if grep -q '/tmp .*nosuid' /proc/mounts; then
 	WORKAROUND_PATH="${XDG_CACHE_HOME:-$HOME/.cache}"/gsr-appimage-hack
 else
 	WORKAROUND_PATH="/tmp/.gsr-appimage-hack"


### PR DESCRIPTION
Fixes #4 

May need improvement in the future for when `XDG_CACHE_HOME` is also at a nosuid location. 

