### PR TITLE
do not use `ld-preload-open`

### DIFF
--- a/AppDir/AppRun
+++ b/AppDir/AppRun
@@ -86,7 +86,6 @@ mkdir -p "$WORKAROUND_PATH"/bin
 if [ ! -f "$WORKAROUND_PATH"/.done ]; then
 	cp "$APPDIR"/sharun*   "$WORKAROUND_PATH"
 	cp "$APPDIR"/.env      "$WORKAROUND_PATH"
-	cp "$APPDIR"/.preload  "$WORKAROUND_PATH"
 	ln -f "$WORKAROUND_PATH"/sharun  "$WORKAROUND_PATH"/bin/gpu-screen-recorder
 	ln -f "$WORKAROUND_PATH"/sharun  "$WORKAROUND_PATH"/bin/gpu-screen-recorder-gtk
 	ln -f "$WORKAROUND_PATH"/sharun  "$WORKAROUND_PATH"/bin/gsr-dbus-server

--- a/AppDir/AppRun
+++ b/AppDir/AppRun
@@ -86,6 +86,7 @@ mkdir -p "$WORKAROUND_PATH"/bin
 if [ ! -f "$WORKAROUND_PATH"/.done ]; then
 	cp "$APPDIR"/sharun*   "$WORKAROUND_PATH"
 	cp "$APPDIR"/.env      "$WORKAROUND_PATH"
+	cp "$APPDIR"/.preload  "$WORKAROUND_PATH" 2>/dev/null || :
 	ln -f "$WORKAROUND_PATH"/sharun  "$WORKAROUND_PATH"/bin/gpu-screen-recorder
 	ln -f "$WORKAROUND_PATH"/sharun  "$WORKAROUND_PATH"/bin/gpu-screen-recorder-gtk
 	ln -f "$WORKAROUND_PATH"/sharun  "$WORKAROUND_PATH"/bin/gsr-dbus-server

--- a/gpu-screen-recorder-appimage.sh
+++ b/gpu-screen-recorder-appimage.sh
@@ -16,16 +16,12 @@ export DESKTOP=/usr/share/applications/com.dec05eba.gpu_screen_recorder.desktop
 export ICON=/usr/share/icons/hicolor/128x128/apps/com.dec05eba.gpu_screen_recorder.png
 export DEPLOY_OPENGL=1
 export DEPLOY_PIPEWIRE=1
-export PATH_MAPPING='/usr/share/gsr-ui:${SHARUN_DIR}/share/gsr-ui:/usr/share/icons/hicolor/32x32/status:${SHARUN_DIR}/share/icons/hicolor/32x32/status:/usr/share/gsr-notify:${SHARUN_DIR}/share/gsr-notify'
 
 # ADD LIBRARIES
 wget --retry-connrefused --tries=30 "$SHARUN" -O ./quick-sharun
 chmod +x ./quick-sharun
 ./quick-sharun /usr/bin/gpu-screen-recorder* /usr/bin/gsr-*
 rm -f ./AppDir/bin/gsr-global-hotkeys ./AppDir/bin/gsr-kms-server
-
-mkdir -p ./AppDir/share/icons/hicolor/32x32
-cp -rv /usr/share/icons/hicolor/32x32/status  ./AppDir/share/icons/hicolor/32x32
 
 # hack
 cp ./AppDir/sharun  ./AppDir/sharun2


### PR DESCRIPTION

Now that `quick-sharun` is smart enough to check for hardcoded paths I don't need to do the patch manually anymore. 

I also don't have to manually add the icons as well.

@fiftydinar https://github.com/pkgforge-dev/gpu-screen-recorder-AppImage/actions/runs/17095961382