### PR TITLE
remove `pipewire-audio`

### DIFF
--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -24,7 +24,6 @@ pacman -Syu --noconfirm \
 	linux-api-headers       \
 	meson                   \
 	libpipewire             \
-	pipewire-jack           \
 	vulkan-headers          \
 	zlib
 

--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -23,7 +23,7 @@ pacman -Syu --noconfirm \
 	libxss                  \
 	linux-api-headers       \
 	meson                   \
-	pipewire-audio          \
+	libpipewire             \
 	pipewire-jack           \
 	vulkan-headers          \
 	zlib


### PR DESCRIPTION
Looks like we don't really need to include this at all. gsr only needs libpipewire for portal access.

But this would need to be tested on a system with Wayland and pipewire-audio to make sure everything works correctly. 

Saves 5 MiB in the final appimage size. 

cc @fiftydinar @QaidVoid

[artifact](https://github.com/Samueru-sama/gpu-screen-recorder-AppImage/releases/tag/5.15.3%402026-08-01_1785556953)